### PR TITLE
1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Version | Description | Date | Author
 -|-|-|-
+1.0.5 | added file header and moved import-module Pester | 2019-10-22 | Josh Burkard
 1.0.4 | Allows to set the module version each time the build.ps1 is started | 2019-10-16 | Josh Burkard
 1.0.3 | Save prefix in json instead of variable | 2019-09-09 | Martin Walther
 1.0.2 | Change return of functions to PsCustomObject | 2019-09-09 | Martin Walther

--- a/CI/Build-Module.ps1
+++ b/CI/Build-Module.ps1
@@ -1,3 +1,10 @@
+<#
+    this file is from to the PSModuleTemplate from 
+
+    https://github.com/tinuwalther/PSModuleTemplate
+
+    for a more accurate version, visit this github repository
+#>
 # Semantic Versioning: https://semver.org/
 
 Write-Host "[BUILD] [START] Launching Build Process" -ForegroundColor Green	
@@ -50,6 +57,11 @@ if(Test-Path -Path $TestsFailures){
     Rename-Item -Path $TestsFailures -NewName $newname
 }
 Write-Host "[BUILD] [TEST]  Running Function-Tests" -ForegroundColor Green
+#region General Module-Tests
+if((Get-Module -Name Pester).Version -match '^3\.\d{1}\.\d{1}'){
+    Remove-Module -Name Pester
+}
+Import-Module -Name Pester -MinimumVersion 4.4.1 -Force
 $TestsResult      = Invoke-Pester -Script $TestsScript -PassThru -Show None
 if($TestsResult.FailedCount -eq 0){    
     $ModuleFolderPath = Join-Path -Path $Root -ChildPath $ModuleName
@@ -104,12 +116,6 @@ if($TestsResult.FailedCount -eq 0){
 
     Write-Host "[BUILD] [END  ] [PSD1] building Manifest" -ForegroundColor Green
     #endregion
-
-    #region General Module-Tests
-    if((Get-Module -Name Pester).Version -match '^3\.\d{1}\.\d{1}'){
-        Remove-Module -Name Pester
-        Import-Module -Name Pester -MinimumVersion 4.4.1
-    }
 
     Describe 'General module control' -Tags 'FunctionalQuality'   {
 

--- a/Code/Get-SCSSomeSettings.ps1
+++ b/Code/Get-SCSSomeSettings.ps1
@@ -1,3 +1,10 @@
+<#
+    this file is from to the PSModuleTemplate from 
+
+    https://github.com/tinuwalther/PSModuleTemplate
+
+    for a more accurate version, visit this github repository
+#>
 
 function Get-SCSSomeSettings{
 

--- a/Tests/.gitignore
+++ b/Tests/.gitignore
@@ -1,0 +1,1 @@
+Functions.Tests*.json

--- a/Tests/Functions.Tests.ps1
+++ b/Tests/Functions.Tests.ps1
@@ -1,5 +1,13 @@
-# Some examples are from Josh Burkard, thanks!
-# https://www.burkard.it/2019/08/pester-tests-for-powershell-functions/
+<#
+    this file is from to the PSModuleTemplate from 
+
+    https://github.com/tinuwalther/PSModuleTemplate
+
+    for a more accurate version, visit this github repository
+
+    Some examples are from Josh Burkard, thanks!
+    https://www.burkard.it/2019/08/pester-tests-for-powershell-functions/
+#>
 
 #region prepare folders
 $Current          = (Split-Path -Path $MyInvocation.MyCommand.Path)
@@ -77,9 +85,11 @@ Get-ChildItem -Path $CodeSourcePath -Filter "*.ps1" | ForEach-Object {
                 }
     
                 $Declaration = ( ( @( $Ast.FindAll( { $true } , $true ) ) | Where-Object { $_.Name.Extent.Text -eq "$('$')$p" } ).Extent.Text -replace 'INT32', 'INT' )
-                $VariableType = ( "\[$( $ScriptCommand.Parameters."$p".ParameterType.Name )\]" -replace 'INT32', 'INT' )
                 $VariableTypeFull = "\[$( $ScriptCommand.Parameters."$p".ParameterType.FullName )\]"
-                $VariableType = $ScriptCommand.Parameters."$p".ParameterType.Name -replace 'INT32', 'INT'
+                $VariableType = $ScriptCommand.Parameters."$p".ParameterType.Name
+                $VariableType = $VariableType -replace 'INT32', 'INT'
+                $VariableType = $VariableType -replace 'String\[\]', 'String'
+                $VariableType = $VariableType -replace 'SwitchParameter', 'Switch'
                 It "$ScriptName type '[$( $ScriptCommand.Parameters."$p".ParameterType.Name )]' should be declared for parameter '$( $p )'" {
                     ( ( $Declaration -match $VariableType ) -or ( $Declaration -match $VariableTypeFull ) ) | Should -Be $true
                 }


### PR DESCRIPTION
- moved import-module Pester inside build.ps1, cause it was after the invoke-Pester and then it would load some times the wrong (old) version
- added file header to show where the templates files are coming from
